### PR TITLE
docs(README.md): GTS spec v0.5 - added Reference Implementation Recommendations

### DIFF
--- a/examples/events/schemas/gts.x.core.events.topic.v1~.schema.json
+++ b/examples/events/schemas/gts.x.core.events.topic.v1~.schema.json
@@ -13,7 +13,7 @@
     "id": {
       "description": "Identifier for the topic/stream in GTS notation.",
       "type": "string",
-      "x-gts-type": "./$id"
+      "x-gts-ref": "./$id"
     },
     "name": { "type": "string", "minLength": 1 },
     "description": { "type": "string" },

--- a/examples/events/schemas/gts.x.core.events.type.v1~.schema.json
+++ b/examples/events/schemas/gts.x.core.events.type.v1~.schema.json
@@ -15,14 +15,14 @@
     "topicRef": {
       "description": "ID of the topic where events of this type are stored.",
       "type": "string",
-      "x-gts-type":"gts.x.core.events.topic.v1~"
+      "x-gts-ref":"gts.x.core.events.topic.v1~"
     }
   },
   "properties": {
     "type": {
       "description": "Identifier of the event type in GTS format.",
       "type": "string",
-      "x-gts-type": "./$id"
+      "x-gts-ref": "./$id"
     },
     "$schema": {
       "description": "Link to the event type schema.",
@@ -82,7 +82,7 @@
     "subjectType": {
       "description": "GTS type of the subject of the event.",
       "type": "string",
-      "x-gts-type": "*",
+      "x-gts-ref": "*",
       "$comment": "The value is mandatory if subject is present"
     }
   },

--- a/examples/events/schemas/gts.x.core.events.type.v1~x.commerce.orders.order_placed.v1.0~.schema.json
+++ b/examples/events/schemas/gts.x.core.events.type.v1~x.commerce.orders.order_placed.v1.0~.schema.json
@@ -25,7 +25,7 @@
         },
         "subjectType": {
           "type": "string",
-          "x-gts-type": "gts.x.commerce.orders.order.v1.0~"
+          "x-gts-ref": "gts.x.commerce.orders.order.v1.0~"
         }
       }
     }

--- a/examples/events/schemas/gts.x.core.events.type.v1~x.commerce.orders.order_placed.v1.1~.schema.json
+++ b/examples/events/schemas/gts.x.core.events.type.v1~x.commerce.orders.order_placed.v1.1~.schema.json
@@ -26,7 +26,7 @@
         },
         "subjectType": {
           "type": "string",
-          "x-gts-type": "gts.x.commerce.orders.order.v1.0~"
+          "x-gts-ref": "gts.x.commerce.orders.order.v1.0~"
         }
       }
     }

--- a/examples/events/schemas/gts.x.core.events.type.v1~x.core.idp.contact_created.v1~.schema.json
+++ b/examples/events/schemas/gts.x.core.events.type.v1~x.core.idp.contact_created.v1~.schema.json
@@ -27,7 +27,7 @@
         },
         "subjectType": {
           "type": "string",
-          "x-gts-type": "gts.x.core.idp.contact.v1.0~"
+          "x-gts-ref": "gts.x.core.idp.contact.v1.0~"
         }
       },
       "x-event-type-settings": {

--- a/examples/mcp/schemas/gts.x.ai.mcp.tool.v1~.schema.jsonc
+++ b/examples/mcp/schemas/gts.x.ai.mcp.tool.v1~.schema.jsonc
@@ -1,0 +1,78 @@
+// purpose: Base MCP Tool manifest schema used to register a tool in a host
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts.x.ai.mcp.tool.v1~",
+  "title": "MCP Tool (Base)",
+  "type": "object",
+  "properties": {
+    "gtsId": {
+      "type": "string",
+      "description": "Full GTS chain for this tool manifest (type lineage + instance)."
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z_][a-z0-9_]*$",
+      "description": "Tool identifier (machine-safe)."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "runtime": {
+      "type": "string",
+      "enum": ["python", "node", "bash", "go", "rust", "http"],
+      "description": "Primary execution runtime."
+    },
+    "timeout_ms": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 600000,
+      "description": "Upper execution time bound."
+    },
+    "security": {
+      "type": "object",
+      "description": "Sandbox/security switches.",
+      "properties": {
+        "allow_network": { "type": "boolean", "default": false },
+        "allow_filesystem": { "type": "boolean", "default": false }
+      },
+      "required": ["allow_network", "allow_filesystem"],
+      "additionalProperties": false
+    },
+    "capabilities": {
+      "type": "object",
+      "description": "Capabilities of the tool type.",
+    },
+    "inputs": {
+      "type": "object",
+      "description": "Named input parameters and simple type metadata.",
+      "patternProperties": {
+        "^[a-z_][a-z0-9_]*$": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string", "enum": ["string", "number", "boolean", "object", "array"] },
+            "required": { "type": "boolean", "default": false },
+            "enum": { "type": "array", "items": { "type": ["string", "number", "boolean"] } },
+            "description": { "type": "string" }
+          },
+          "required": ["type"],
+          "additionalProperties": false
+        }
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    },
+    "outputs": {
+      "type": "object",
+      "description": "Primary output descriptor.",
+      "properties": {
+        "type": { "type": "string", "enum": ["string", "number", "boolean", "object", "array"] },
+        "description": { "type": "string" }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["gtsId", "name", "description", "runtime", "timeout_ms", "security", "inputs", "outputs"],
+  "additionalProperties": false
+}

--- a/examples/mcp/schemas/gts.x.ai.mcp.tool.v1~x.ai.mcp.http_outbound.v1~.schema.jsonc
+++ b/examples/mcp/schemas/gts.x.ai.mcp.tool.v1~x.ai.mcp.http_outbound.v1~.schema.jsonc
@@ -1,0 +1,53 @@
+// purpose: Derived MCP Tool requiring HTTP outbound capability with domain/method constraints
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts.x.ai.mcp.tool.v1~x.core.mcp.http_outbound.v1~",
+  "title": "MCP Tool with HTTP Outbound Capability",
+  "type": "object",
+  "allOf": [
+    { "$ref": "gts.x.ai.mcp.tool.v1~",
+    {
+      "type": "object",
+      "properties": {
+        "security": {
+          "type": "object",
+          "properties": {
+            "allow_network": { "const": true }, // Force true for HTTP outbound tools
+            "allow_filesystem": { "const": false } // Force false for HTTP outbound tools
+          },
+          "required": ["allow_network", "allow_filesystem"],
+          "additionalProperties": false
+        },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "http_outbound": {
+              "type": "object",
+              "properties": { // Specific tools instances will need to specify 'allowed_domains' and 'allowed_methods', etc
+                "allowed_domains": {
+                  "type": "array",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": { "type": "string", "pattern": "^[a-z0-9.-]+$" }
+                },
+                "allowed_methods": {
+                  "type": "array",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": { "type": "string", "enum": ["GET", "HEAD", "POST"] }
+                },
+                "max_response_bytes": { "type": "integer", "minimum": 1024, "maximum": 10485760 }
+              },
+              "required": ["allowed_domains", "allowed_methods", "max_response_bytes"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["http_outbound"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["security", "capabilities"],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/examples/mcp/schemas/gts.x.genai.mcp.tools.v1.0~.schema.json
+++ b/examples/mcp/schemas/gts.x.genai.mcp.tools.v1.0~.schema.json
@@ -12,7 +12,7 @@
     "type": {
       "description": "Identifier of the tool type in GTS format.",
       "type": "string",
-      "x-gts-type": "./$id"
+      "x-gts-ref": "./$id"
     },
     "name": {
       "type": "string",

--- a/examples/modules/README.md
+++ b/examples/modules/README.md
@@ -1,0 +1,25 @@
+# Modules examples
+
+This folder contains a simple self-contained examples for a pluggable SaaS service that supports modules with custom configs, and also needs to know modules capabilities in order to define API gateway properly
+
+##  Schemas (`schemas/`)
+
+- `schemas/gts.x.core.modules.capability.v1~.schema.json` - Base schema for a capability
+- `schemas/gts.x.core.modules.module.v1~.schema.json` - Base schema for a module. Fields:
+    - `capabilities`: array of capabilities this module provides
+    - `requirements`: array of required modules
+
+## Instances (`instances/`)
+
+- `gts.x.core.modules.capability.v1~x.core.api.has_ws.v1.json` — example capability (supports WebSocket)
+- `gts.x.core.modules.capability.v1~x.core.api.is_rest.v1.json` — example capability (is REST)
+- `gts.x.core.modules.capability.v1~x.core.api.is_sse.v1.json` — example capability (supports SSE)
+- `gts.x.core.modules.module.v1~x.webstore._.catalog.v1.json` — example module (catalog)
+- `gts.x.core.modules.module.v1~x.webstore._.chat.v1.json` — example module (chat)
+
+## Notes
+
+- `x-gts-ref` marks that a string field must be a valid GTS identifier:
+  - `"gts..."` — any valid GTS ID of the referenced family.
+  - `"./$id"` — self-reference to the current JSON Schema’s `$id`.
+- These examples are illustrative and can be used to test parsing, validation, and reference resolution in GTS-aware tooling.

--- a/examples/modules/instances/gts.x.core.modules.capability.v1~x.core.api.has_ws.v1.json
+++ b/examples/modules/instances/gts.x.core.modules.capability.v1~x.core.api.has_ws.v1.json
@@ -1,0 +1,4 @@
+{
+    "id": "gts.x.core.modules.capability.v1~x.core.api.has_ws.v1",
+    "description": "Capability representing the module ability to support WebSocket APIs."
+}

--- a/examples/modules/instances/gts.x.core.modules.capability.v1~x.core.api.is_rest.v1.json
+++ b/examples/modules/instances/gts.x.core.modules.capability.v1~x.core.api.is_rest.v1.json
@@ -1,0 +1,4 @@
+{
+    "id": "gts.x.core.modules.capability.v1~x.core.api.has_rest.v1",
+    "description": "Capability representing the module ability to host RESTful APIs."
+}

--- a/examples/modules/instances/gts.x.core.modules.capability.v1~x.core.api.is_sse.v1.json
+++ b/examples/modules/instances/gts.x.core.modules.capability.v1~x.core.api.is_sse.v1.json
@@ -1,0 +1,4 @@
+{
+    "id": "gts.x.core.modules.capability.v1~x.core.api.has_sse.v1",
+    "description": "Capability representing the module ability to stream server side events."
+}

--- a/examples/modules/instances/gts.x.core.modules.module.v1~x.webstore._.catalog.v1.json
+++ b/examples/modules/instances/gts.x.core.modules.module.v1~x.webstore._.catalog.v1.json
@@ -1,0 +1,19 @@
+{
+  "id": "gts.x.core.modules.module.v1~x.webstore._.catalog.v1",
+  "displayName": "WebStore Product Catalog module",
+  "description": "WebStore module providing Products Catalog capabilities.",
+  "capabilities": [
+    "gts.x.core.modules.capability.v1~x.core.api.has_rest.v1"    
+  ],
+  "requirements": [],
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "default_products_view": { "type": "string", "enum": ["table", "list"] },
+      "default_products_per_page": { "type": "int", "minimum": 1, "maximum": 100, "default": 20 },
+      "default_region": { "type": "string", "description": "Default region for product availability" },
+    },
+    "required": ["default_region"],
+    "additionalProperties": false
+  }
+}

--- a/examples/modules/instances/gts.x.core.modules.module.v1~x.webstore._.chat.v1.json
+++ b/examples/modules/instances/gts.x.core.modules.module.v1~x.webstore._.chat.v1.json
@@ -1,0 +1,36 @@
+{
+  "id": "gts.x.core.modules.module.v1~x.webstore._.chat.v1",
+  "displayName": "WebStore Chat Module",
+  "description": "WebStore module providing chat capabilities.",
+  "capabilities": [
+    "gts.x.core.modules.capability.v1~x.core.api.has_rest.v1",
+    "gts.x.core.modules.capability.v1~x.core.api.has_ws.v1",
+    "gts.x.core.modules.capability.v1~x.core.api.has_sse.v1"         
+  ],
+  "requirements": [
+    "gts.x.core.modules.module.v1~x.webstore._.catalog.v1"        
+  ],
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "max_retention": {
+        "type": "int",
+        "description": "Max chat messages retention in days",
+        "default": "90",
+        "minimum": 0,
+        "maximum": 356,
+      },
+      "max_file_size": {
+        "type": "int",
+        "description": "Max chat attachment file size in MegaBytes"
+      },
+      "search_in_catalog": {
+        "type": "boolean",
+        "description": "Enable searching products from catalog in chat",
+        "default": true
+      }
+    },
+    "required": ["max_file_size"],
+    "additionalProperties": false
+  }
+}

--- a/examples/modules/schemas/gts.x.core.modules.capability.v1~.schema.json
+++ b/examples/modules/schemas/gts.x.core.modules.capability.v1~.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "gts.x.core.modules.capability.v1~",
+  "description": "Base schema for any application modules capabilities",
+  "required": ["description", "id"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "x-gts-ref": "./$id"
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 500
+    },
+    "additionalProperties": false
+  }
+}

--- a/examples/modules/schemas/gts.x.core.modules.module.v1~.schema.json
+++ b/examples/modules/schemas/gts.x.core.modules.module.v1~.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "gts.x.core.modules.module.v1~",
+  "type": "object",
+  "description": "Base schema for any application modules.",
+  "title": "Module metadata",
+  "required": ["displayName", "description"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "x-gts-ref": "./$id"
+    },
+    "displayName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 500
+    },
+    "capabilities": {
+      "type": "array",
+      "description": "List of capabilities provided by this module.",
+      "items": {
+        "type": "string",
+        "x-gts-ref": "gts.x.core.modules.capability.v1~"
+      },
+      "minItems": 0,
+      "uniqueItems": true
+    },
+    "requirements": {
+      "type": "array",
+      "description": "List of required modules.",
+      "items": {
+        "type": "string",
+        "x-gts-ref": "./$id"
+      },
+      "minItems": 0,
+      "uniqueItems": true
+    },
+    "configSchema": {
+      "type": "object",
+      "description": "Module config schema defining the configuration structure for this module.",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["object"],
+          "description": "Indicates that configuration is structured as a JSON schema."
+        },
+        "properties": {
+          "type": "object",
+          "description": "configSchema properties",
+        },
+        "required": {
+          "type": "array",
+          "description": "Fields required within the configSchema object."
+        },
+        "additionalProperties": {
+          "type": "boolean",
+          "description": "Whether additional properties are allowed in the configSchema object."
+        }
+      }
+    }
+  }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Tests
 
-This directory contains test cases for the GTS specification operations. The test cases are implemented using Pytest and are designed to run against any web server implementing the GTS operations API.
+This directory contains test cases for the GTS specification [reference implementation recommendations](../README.md#9-reference-implementation-recommendations). The test cases are implemented using Pytest and are designed to run against any web server implementing the GTS operations API.
 
 ## Architecture Rationale
 


### PR DESCRIPTION
Provided Implementation recommendations for:
- **CLI** - command-line interface for all GTS operations
- **Web server** - a non-production web-server with REST API for the operations processing and testing
- **x-gts-ref support** - to support special GTS entity reference annotation in schemas
- **YAML support** - to support YAML files (*.yml, *.yaml) as input files
- **TypeSpec support** - add [typespec.io](https://typespec.io/) files (*.tsp) support
- **UUID for instances** - to support UUID as ID in JSON instances

Added tests for: x-gts-ref in `./examples/modules/`