### PR TITLE
spec: introduce GTS Type Schema and rename GTS Type Registry → GTS Registry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ gts-spec/
 ├── LICENSE                   # License information
 └── examples/                 # Example GTS Types and instances
     ├── events/               # Event-related examples
-    │   ├── types/            # GTS Type definitions (JSON Schema files inside)
+    │   ├── types/            # GTS Type Schemas (JSON Schema documents)
     │   └── instances/        # JSON instance examples
     └── ...                   # Other domain examples
 ```
@@ -114,5 +114,5 @@ Specification development guidelines:
 - Follow GTS identifier format rules strictly
 - Ensure all schemas use correct `$id` values
 - Validate schemas against JSON Schema Draft 7 or later
-- Include both GTS Types (with their JSON Schema representations) and GTS Instance examples
+- Include both GTS Type Schemas (the canonical JSON definitions of types) and GTS Instance examples
 - Document any deviations or implementation-specific choices

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **VERSION**: GTS specification draft, version 0.10
+> **VERSION**: GTS specification draft, version 0.11
 
 # Global Type System (GTS) Specification
 
@@ -63,13 +63,13 @@ See the [Practical Benefits for Service and Platform Vendors](#51-practical-bene
 - [4. GTS Identifier Versions Compatibility](#4-gts-identifier-versions-compatibility)
   - [4.1 Compatibility Modes](#41-compatibility-modes)
   - [4.2 JSON Schema Content Models](#42-json-schema-content-models)
-  - [4.3 Compatibility Rules](#43-compatibility-rules)
+  - [4.3 Compatibility Rules for GTS Type Schemas](#43-compatibility-rules-for-gts-type-schemas)
   - [4.4 GTS Versions Compatibility Examples](#44-gts-versions-compatibility-examples)
-  - [4.5 Best Practices for Schema Evolution](#45-best-practices-for-schema-evolution)
+  - [4.5 Best Practices for GTS Type Schema Evolution](#45-best-practices-for-gts-type-schema-evolution)
 - [5. Typical Use-cases](#5-typical-use-cases)
   - [5.1 Practical Benefits for Service and Platform Vendors](#51-practical-benefits-for-service-and-platform-vendors)
   - [5.2 Example: Multi-vendor Event Management Platform](#52-example-multi-vendor-event-management-platform)
-  - [5.3 GTS Type Registry Requirement](#53-gts-type-registry-requirement)
+  - [5.3 GTS Registry Requirement](#53-gts-registry-requirement)
 - [6. Implementation-defined and Non-goals](#6-implementation-defined-and-non-goals)
 - [7. Comparison with other identifiers](#7-comparison-with-other-identifiers)
 - [8. Parsing and Validation](#8-parsing-and-validation)
@@ -82,11 +82,11 @@ See the [Practical Benefits for Service and Platform Vendors](#51-practical-bene
   - [9.4 CLI support](#94---cli-support)
   - [9.5 Web server with OpenAPI](#95---web-server-with-openapi)
   - [9.6 `x-gts-ref` support](#96---x-gts-ref-support)
-  - [9.7 Schema Traits (`x-gts-traits-schema` / `x-gts-traits`)](#97---schema-traits-x-gts-traits-schema--x-gts-traits)
+  - [9.7 GTS Type Schema Traits (`x-gts-traits-schema` / `x-gts-traits`)](#97---gts-type-schema-traits-x-gts-traits-schema--x-gts-traits)
   - [9.8 YAML support](#98---yaml-support)
   - [9.9 TypeSpec support](#99---typespec-support)
   - [9.10 UUID as object IDs](#910---uuid-as-object-ids)
-  - [9.11 Schema Modifiers (`x-gts-final` / `x-gts-abstract`)](#911---schema-modifiers-x-gts-final--x-gts-abstract)
+  - [9.11 GTS Type Schema Modifiers (`x-gts-final` / `x-gts-abstract`)](#911---gts-type-schema-modifiers-x-gts-final--x-gts-abstract)
 - [10. Collecting Identifiers with Wildcards](#10-collecting-identifiers-with-wildcards)
 - [11. JSON and JSON Schema Conventions](#11-json-and-json-schema-conventions)
 - [12. Notes and Best Practices](#12-notes-and-best-practices)
@@ -110,20 +110,20 @@ See the [Practical Benefits for Service and Platform Vendors](#51-practical-bene
 | 0.8 | Add alternate combined anonymous instance identifier format |
 | 0.9 | Add `x-gts-final` and `x-gts-abstract` schema modifiers; enforce final/abstract semantics in OP#6 and OP#12 |
 | 0.10 | BREAKING: terminology unified around GTS Type / GTS Instance; rename API fields `schema_id` → `type_id` (also `old_schema_id`/`new_schema_id`/`to_schema_id`/`selected_schema_id_field`); rename API field `is_schema` → `is_type` (type-definition vs instance discriminator); `type_id` MUST be a GTS Type Identifier or `null` — no longer falls back to JSON Schema dialect URL; rename endpoints `/validate-schema` → `/validate-type`, `/schemas` → `/types`; rename OP#12 'Schema vs Schema Validation' → 'Type Derivation Validation'; rename OpenAPI components `ValidateSchemaRequest` → `ValidateTypeRequest`, `SchemaRegister` → `TypeRegister`; rename example directories `examples/**/schemas/` → `examples/**/types/` (file extensions `.schema.json` retained); add Terminology section |
+| 0.11 | Introduce term **GTS Type Schema** as the canonical definition of a GTS Type; remove the standalone `Schema` term from Terminology; rewrite `GTS Type` entry to name the abstract registered entity; rename `GTS Type Registry` → `GTS Registry` (registry now scopes both Type Schemas and well-known Instances). **Conformance tests for reference implementations** also updated: rename API endpoints `/validate-type` → `/validate-type-schema` and `/types` → `/type-schemas`; rename OpenAPI components `TypeRegister` → `TypeSchemaRegister`, `ValidateTypeRequest` → `ValidateTypeSchemaRequest`; rename request field `TypeSchemaRegister.schema` → `TypeSchemaRegister.type_schema`; rename helper `validate_type` → `validate_type_schema`. |
 
 ## Terminology
 
 This specification uses the following terms with precise meanings:
 
-- **GTS Type**: a logical type definition or contract. It may include schema representations, traits, metadata, compatibility rules, lifecycle information, relations, and other type-level information.
+- **GTS Type**: a type entity identified by a GTS Type Identifier and defined by a GTS Type Schema. A GTS Type may exist as a standalone document (e.g., a `*.schema.json` file), be exchanged between systems, or be stored in a GTS Registry.
 - **GTS Type Identifier**: a canonical GTS identifier ending with `~` that identifies a GTS Type.
-- **Schema**: a structural definition or representation of a GTS Type (typically a JSON Schema document). A schema is only one part of a type definition.
-- **GTS Type Registry**: a registry that stores and resolves GTS Type definitions by GTS Type Identifier.
+- **GTS Type Schema**: the canonical definition of a GTS Type — a JSON Schema document annotated with the GTS vocabulary (`x-gts-*`), describing the type's instance shape, traits, metadata, compatibility rules, lifecycle, and relations.
+
+  Implementations MAY accept alternative source forms (e.g., TypeSpec, YAML) provided they deterministically map to a canonical GTS Type Schema. The canonical form, used for interchange, validation, and registration, is the JSON Schema document.
+- **GTS Registry**: a registry that stores and resolves GTS entities — Type Schemas and well-known Instances — by GTS Identifier.
 - **GTS Instance**: a concrete object, value, or document that conforms to a GTS Type.
 - **GTS Instance Identifier**: a GTS identifier without the trailing `~`, used to identify a well-known instance.
-
-Throughout this document, the term **schema** is used in the JSON Schema sense — i.e., the structural/validation representation of a GTS Type. The primary GTS concept is the **GTS Type**, of which a schema is one possible representation.
-
 
 ## 1. Motivation
 
@@ -618,11 +618,11 @@ These models affect which changes are safe:
 - Adding a field to a **closed** model is backward compatible (old data has no extra fields; new consumers handle absence).
 - Adding/removing optional fields in an **open** model is fully compatible (open consumers accept any fields; optional fields can be absent).
 
-### 4.3 Compatibility Rules for GTS Schemas
+### 4.3 Compatibility Rules for GTS Type Schemas
 
 The table below shows which schema changes between minor versions of the same type are safe for each compatibility mode.
 
-> NOTE: The table below illustrates the compatibility rules for GTS schemas of the same type, but different versions. The derived types are always fully compatible with the base type.
+> NOTE: The table below illustrates the compatibility rules for GTS Type Schemas of the same type, but different versions. The derived types are always fully compatible with the base type.
 
 | Change | Backward | Forward | Full | Notes |
 |--------|----------|---------|------|-------|
@@ -928,7 +928,7 @@ This section demonstrates how different types of schema changes affect compatibi
 See the [examples folder](./examples/events/types/) for complete schema definitions demonstrating these patterns.
 
 
-### 4.5 Best Practices for Schema Evolution
+### 4.5 Best Practices for GTS Type Schema Evolution
 
 To maximize compatibility and minimize breaking changes between the minor versions of the same GTS type, follow these recommendations:
 
@@ -940,7 +940,7 @@ To maximize compatibility and minimize breaking changes between the minor versio
 
 4. **Avoid changing field types**: Type changes are almost always breaking. To evolve a type, use union types: `"type": ["string", "number"]`.
 
-5. **Use a GTS Type Registry**: Centralize GTS Type management and enforce compatibility checks before allowing new versions to be published.
+5. **Use a GTS Registry**: Centralize GTS Type management and enforce compatibility checks before allowing new versions to be published.
 
 
 ## 5. Typical Use-cases
@@ -1123,11 +1123,11 @@ See additional GTS examples in the [examples folder](./examples/):
 - [YAML UI Examples](./examples/yaml/ui/) - User interface component definitions (menus, grids) in YAML format
 
 
-### 5.3 GTS Type Registry Requirement
+### 5.3 GTS Registry Requirement
 
-> **Critical implementation requirement:** The architectural guarantees of GTS—particularly type safety across inheritance chains and safe minor version evolution—depend entirely on a stateful **GTS Type Registry** component. Production systems MUST implement or integrate a registry capable of:
+> **Critical implementation requirement:** The architectural guarantees of GTS—particularly type safety across inheritance chains and safe minor version evolution—depend entirely on a stateful **GTS Registry** component. Production systems MUST implement or integrate a registry capable of:
 >
-> 1. **Storing and indexing** all registered GTS Types by their GTS Type Identifiers
+> 1. **Storing and indexing** all registered GTS Type Schemas by their GTS Type Identifiers
 > 2. **Validating compatibility** of new GTS Type versions against existing versions using the precise rules defined in section 4.3 before publication
 > 3. **Enforcing inheritance constraints** to ensure derived types remain compatible with their base types
 > 4. **Rejecting incompatible changes** that violate the declared compatibility mode (backward/forward/full)
@@ -1332,11 +1332,11 @@ Implementation notes:
   - For nested paths (e.g., `./properties/id`), resolve the pointer accordinly to the field path in the JSON Schema document.
 
 
-### 9.7 - Schema Traits (`x-gts-traits-schema` / `x-gts-traits`)
+### 9.7 - GTS Type Schema Traits (`x-gts-traits-schema` / `x-gts-traits`)
 
-**OP#13 - Schema Traits Validation**: Validate that `x-gts-traits` values in derived schemas conform to the `x-gts-traits-schema` defined in their base schemas. Verify that all trait properties are resolved (via direct value or `default`) and that trait values satisfy the trait schema constraints. Trait values set by an ancestor are immutable — descendants MUST NOT override them with a different value. Both `x-gts-traits-schema` and `x-gts-traits` are schema-only keywords and MUST NOT appear in instances. `x-gts-traits-schema` MUST have `"type": "object"`. Uses the same validation endpoints (`/validate-type`, `/validate-entity`).
+**OP#13 - Schema Traits Validation**: Validate that `x-gts-traits` values in derived schemas conform to the `x-gts-traits-schema` defined in their base schemas. Verify that all trait properties are resolved (via direct value or `default`) and that trait values satisfy the trait schema constraints. Trait values set by an ancestor are immutable — descendants MUST NOT override them with a different value. Both `x-gts-traits-schema` and `x-gts-traits` are schema-only keywords and MUST NOT appear in instances. `x-gts-traits-schema` MUST have `"type": "object"`. Uses the same validation endpoints (`/validate-type-schema`, `/validate-entity`).
 
-A **schema trait** is a semantic annotation attached to a GTS schema that describes **system behaviour** for processing instances of that type. Traits are not part of the object data model — they do not define instance properties. Instead, they configure cross-cutting concerns such as:
+A **schema trait** is a semantic annotation attached to a GTS Type Schema that describes **system behaviour** for processing instances of that type. Traits are not part of the object data model — they do not define instance properties. Instead, they configure cross-cutting concerns such as:
 
 - **Retention rules** — how long instances of this type are kept (e.g., object TTL)
 - **Processing directives** — how attributes should be handled (e.g., PII masking, indexing hints)
@@ -1531,9 +1531,9 @@ Ensure generated schemas use GTS identifiers as `$id` for types and keep any `x-
 
 Support UUIDs (format: `uuid`) for instance `id` fields.
 
-### 9.11 - Schema Modifiers (`x-gts-final` / `x-gts-abstract`)
+### 9.11 - GTS Type Schema Modifiers (`x-gts-final` / `x-gts-abstract`)
 
-A **schema modifier** is a boolean annotation on a GTS schema that restricts how the type participates in the GTS type system. Modifiers can be used to control inheritance and instantiation behavior. There are two keywords for this purpose: `x-gts-final` and `x-gts-abstract`.
+A **schema modifier** is a boolean annotation on a GTS Type Schema that restricts how the type participates in the GTS type system. Modifiers can be used to control inheritance and instantiation behavior. There are two keywords for this purpose: `x-gts-final` and `x-gts-abstract`.
 
 #### 9.11.1 Keywords
 
@@ -1561,7 +1561,7 @@ When a schema declares `"x-gts-final": true`:
 
 1. **Registration guard**: When a new schema is registered whose `allOf` / `$ref` chain references a final type as a base, the registry MUST reject the registration (when validation is enabled). Specifically, if the derived schema's `$id` is of the form `gts://gts.A~B~` and schema `A~` has `"x-gts-final": true`, then registering `A~B~` MUST fail.
 
-2. **Validation via `/validate-type` (OP#12)**: When validating a derived schema against its base chain, if any base schema in the chain is marked `x-gts-final`, validation MUST fail with an error indicating that the base type is final and cannot be extended.
+2. **Validation via `/validate-type-schema` (OP#12)**: When validating a derived schema against its base chain, if any base schema in the chain is marked `x-gts-final`, validation MUST fail with an error indicating that the base type is final and cannot be extended.
 
 3. **Instances are unaffected**: A final type MAY have well-known instances and anonymous instances. `x-gts-final` restricts only schema derivation, not instantiation.
 
@@ -1616,7 +1616,7 @@ When a schema declares `"x-gts-abstract": true`:
 
 #### 9.11.5 Registration enforcement
 
-Enforcement follows the same pattern as existing `?validate=true` behavior: checks are performed when validation is enabled on registration, and always enforced on explicit validation endpoints (`/validate-type`, `/validate-instance`, `/validate-entity`). This is consistent with existing patterns (e.g., `x-gts-ref` checks in section 9.6).
+Enforcement follows the same pattern as existing `?validate=true` behavior: checks are performed when validation is enabled on registration, and always enforced on explicit validation endpoints (`/validate-type-schema`, `/validate-instance`, `/validate-entity`). This is consistent with existing patterns (e.g., `x-gts-ref` checks in section 9.6).
 
 See `./examples/typespec/vms/types/states/gts.x.infra.compute.vm_state.v1~.schema.json` for an example of a final type, `./examples/modules/types/gts.x.core.modules.capability.v1~.schema.json` for another final type, and `./examples/events/types/gts.x.core.events.type.v1~.schema.json` for an example of an abstract base type.
 
@@ -1718,9 +1718,10 @@ Implementations MUST normalize this by stripping the `gts://` prefix when extrac
 
 Implementations MUST clearly distinguish the following **five** categories of JSON documents:
 
-1. **GTS entity schemas**
+1. **GTS Type Schemas**
    - Have `$schema`
-   - Have `$id` starting with `gts://` and the remainder is a valid **GTS type identifier** (ends with `~`)
+   - Have `$id` starting with `gts://` and the remainder is a valid **GTS Type Identifier** (ends with `~`)
+   - This is the canonical JSON representation of a GTS Type Schema. Files named `*.schema.json` carry such documents.
    - Example:
 
 ```json

--- a/tests/helpers/http_run_helpers.py
+++ b/tests/helpers/http_run_helpers.py
@@ -60,11 +60,11 @@ def register_instance(instance_body, label="register instance"):
     )
 
 
-def validate_type(type_id, expect_ok, label="validate type"):
-    """Validate a derived type via POST /validate-type."""
+def validate_type_schema(type_id, expect_ok, label="validate type schema"):
+    """Validate a derived GTS Type Schema via POST /validate-type-schema."""
     step = (
         RunRequest(label)
-        .post("/validate-type")
+        .post("/validate-type-schema")
         .with_json({"type_id": type_id})
         .validate()
         .assert_equal("status_code", 200)

--- a/tests/openapi.json
+++ b/tests/openapi.json
@@ -175,17 +175,17 @@
         }
       }
     },
-    "/types": {
+    "/type-schemas": {
       "post": {
-        "summary": "Register a GTS Type by explicit type_id",
-        "operationId": "add_type_types_post",
+        "summary": "Register a GTS Type Schema under an explicit type_id",
+        "operationId": "add_type_schema_type_schemas_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/TypeRegister"
+                    "$ref": "#/components/schemas/TypeSchemaRegister"
                   }
                 ],
                 "title": "Body"
@@ -469,17 +469,17 @@
         }
       }
     },
-    "/validate-type": {
+    "/validate-type-schema": {
       "post": {
-        "summary": "Validate that a derived type correctly extends its base chain",
-        "operationId": "validate_type_validate_type_post",
+        "summary": "Validate that a derived GTS Type Schema correctly extends its base chain",
+        "operationId": "validate_type_schema_validate_type_schema_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/ValidateTypeRequest"
+                    "$ref": "#/components/schemas/ValidateTypeSchemaRequest"
                   }
                 ],
                 "title": "Body"
@@ -495,7 +495,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "title": "Response Validate Type Validate Type Post"
+                  "title": "Response Validate Type Schema Validate Type Schema Post"
                 }
               }
             }
@@ -515,7 +515,7 @@
     },
     "/validate-entity": {
       "post": {
-        "summary": "Validate entity (instance or schema) by GTS ID",
+        "summary": "Validate entity (instance or type schema) by GTS Identifier",
         "operationId": "validate_entity_validate_entity_post",
         "requestBody": {
           "content": {
@@ -816,23 +816,23 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
-      "TypeRegister": {
+      "TypeSchemaRegister": {
         "properties": {
           "type_id": {
             "type": "string",
             "title": "Type Id"
           },
-          "schema": {
+          "type_schema": {
             "type": "object",
-            "title": "Schema"
+            "title": "Type Schema"
           }
         },
         "type": "object",
         "required": [
           "type_id",
-          "schema"
+          "type_schema"
         ],
-        "title": "TypeRegister"
+        "title": "TypeSchemaRegister"
       },
       "ValidateInstanceRequest": {
         "properties": {
@@ -847,7 +847,7 @@
         ],
         "title": "ValidateInstanceRequest"
       },
-      "ValidateTypeRequest": {
+      "ValidateTypeSchemaRequest": {
         "properties": {
           "type_id": {
             "type": "string",
@@ -858,7 +858,7 @@
         "required": [
           "type_id"
         ],
-        "title": "ValidateTypeRequest"
+        "title": "ValidateTypeSchemaRequest"
       },
       "ValidateEntityRequest": {
         "properties": {

--- a/tests/test_op12_type_derivation_validation.py
+++ b/tests/test_op12_type_derivation_validation.py
@@ -2,7 +2,7 @@ from .conftest import get_gts_base_url
 from .helpers.http_run_helpers import (
     register as _register,
     register_derived as _register_derived,
-    validate_type as _validate_type,
+    validate_type_schema as _validate_type_schema,
 )
 from httprunner import HttpRunner, Config, Step, RunRequest
 
@@ -43,7 +43,7 @@ def _make_2level_constraint_drop_steps(
             }},
             f"register derived dropping {constraint_kw}",
         ),
-        _validate_type(
+        _validate_type_schema(
             type_id, False,
             f"validate should fail - {constraint_kw} dropped",
         ),
@@ -83,7 +83,7 @@ def _make_3level_const_steps(
             }},
             f"register L2 with const {l2_const!r}",
         ),
-        _validate_type(l2_type_id, True, "validate L2"),
+        _validate_type_schema(l2_type_id, True, "validate L2"),
         _register_derived(
             l3_schema_id, l2_schema_id,
             {"type": "object", "properties": {
@@ -91,7 +91,7 @@ def _make_3level_const_steps(
             }},
             f"register L3 with const {l3_const!r}",
         ),
-        _validate_type(l3_type_id, expect_l3_ok, "validate L3"),
+        _validate_type_schema(l3_type_id, expect_l3_ok, "validate L3"),
     ]
 
 
@@ -138,7 +138,7 @@ def _make_3level_loosening_steps(
             }},
             f"register L2 tightening {keyword} to {l2_constraint}",
         ),
-        _validate_type(l2_type_id, True, "validate L2"),
+        _validate_type_schema(l2_type_id, True, "validate L2"),
         _register_derived(
             l3_schema_id, l2_schema_id,
             {"type": "object", "properties": {
@@ -146,7 +146,7 @@ def _make_3level_loosening_steps(
             }},
             f"register L3 loosening {keyword} to {l3_constraint}",
         ),
-        _validate_type(l3_type_id, expect_l3_ok, "validate L3"),
+        _validate_type_schema(l3_type_id, expect_l3_ok, "validate L3"),
     ]
 
 
@@ -209,17 +209,10 @@ class TestCaseTestOp12TypeDerivationValidation_DerivedSchemaFullyMatches(HttpRun
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate derived schema against base")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12a.base.user.v1~x.test12a._.premium_user.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12a.base.user.v1~x.test12a._.premium_user.v1~",
+            True,
+            "validate derived schema against base",
         ),
     ]
 
@@ -278,17 +271,10 @@ class TestCaseTestOp12TypeDerivationValidation_DerivedSchemaAddsNewFieldsToBaseO
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate derived schema against base")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12b.base.user.v1~x.test12b._.premium_user.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12b.base.user.v1~x.test12b._.premium_user.v1~",
+            True,
+            "validate derived schema against base",
         ),
     ]
 
@@ -352,18 +338,11 @@ class TestCaseTestOp12TypeDerivationValidation_AdditionalPropertiesFalse(
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate should fail - base forbids extra properties")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.closed.account.v1~"
-                    "x.test12._.premium_account.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", False)
+        _validate_type_schema(
+            "gts.x.test12.closed.account.v1~"
+            "x.test12._.premium_account.v1~",
+            False,
+            "validate should fail - base forbids extra properties",
         ),
     ]
 
@@ -427,18 +406,11 @@ class TestCaseTestOp12TypeDerivationValidation_CloseOpenModel(HttpRunner):
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate derived schema should pass")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.close.user.v1~"
-                    "x.test12._.closed_user.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.close.user.v1~"
+            "x.test12._.closed_user.v1~",
+            True,
+            "validate derived schema should pass",
         ),
     ]
 
@@ -512,18 +484,11 @@ class TestCaseTestOp12TypeDerivationValidation_NestedAdditionalPropertiesFalse(
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate derived schema should fail")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.nested.closed.v1~"
-                    "x.test12._.profile_plus.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", False)
+        _validate_type_schema(
+            "gts.x.test12.nested.closed.v1~"
+            "x.test12._.profile_plus.v1~",
+            False,
+            "validate derived schema should fail",
         ),
     ]
 
@@ -580,17 +545,10 @@ class TestCaseTestOp12TypeDerivationValidation_InvalidDerivedSchema(
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate derived schema should fail")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.base.order.v1~x.test12._.bad_order.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", False)
+        _validate_type_schema(
+            "gts.x.test12.base.order.v1~x.test12._.bad_order.v1~",
+            False,
+            "validate derived schema should fail",
         ),
     ]
 
@@ -659,17 +617,10 @@ class TestCaseTestOp12TypeDerivationValidation_DerivedSchemaConstraintTighten(
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate derived schema with tighter constraints")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.base.text.v1~x.test12._.short_text.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.base.text.v1~x.test12._.short_text.v1~",
+            True,
+            "validate derived schema with tighter constraints",
         ),
     ]
 
@@ -725,17 +676,10 @@ class TestCaseTestOp12TypeDerivationValidation_DerivedSchemaConstraintLoosen(
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate schema with looser constraints should fail")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.base.data.v1~x.test12._.loose_data.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", False)
+        _validate_type_schema(
+            "gts.x.test12.base.data.v1~x.test12._.loose_data.v1~",
+            False,
+            "validate schema with looser constraints should fail",
         ),
     ]
 
@@ -803,18 +747,11 @@ class TestCaseTestOp12TypeDerivationValidation_DerivedSpecifiesObject(HttpRunner
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate derived schema specifying object")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.objspec.event.v1~"
-                    "x.test12._.order_event.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.objspec.event.v1~"
+            "x.test12._.order_event.v1~",
+            True,
+            "validate derived schema specifying object",
         ),
     ]
 
@@ -884,18 +821,11 @@ class TestCaseTestOp12TypeDerivationValidation_3Level_L2SpecifiesObject(HttpRunn
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate L2 schema")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.obj3a.resource.v1~"
-                    "x.test12._.file.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.obj3a.resource.v1~"
+            "x.test12._.file.v1~",
+            True,
+            "validate L2 schema",
         ),
         Step(
             RunRequest("register L3 schema tightening the object")
@@ -943,18 +873,11 @@ class TestCaseTestOp12TypeDerivationValidation_3Level_L2SpecifiesObject(HttpRunn
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate L3 schema")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.obj3a.resource.v1~"
-                    "x.test12._.file.v1~x.test12._.image.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.obj3a.resource.v1~"
+            "x.test12._.file.v1~x.test12._.image.v1~",
+            True,
+            "validate L3 schema",
         ),
     ]
 
@@ -1032,18 +955,11 @@ class TestCaseTestOp12TypeDerivationValidation_3Level_L2CompositionL3NestedObjec
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate L2 schema")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.obj3b.config.v1~"
-                    "x.test12._.app_config.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.obj3b.config.v1~"
+            "x.test12._.app_config.v1~",
+            True,
+            "validate L2 schema",
         ),
         Step(
             RunRequest("register L3 specifying the nested object")
@@ -1115,19 +1031,12 @@ class TestCaseTestOp12TypeDerivationValidation_3Level_L2CompositionL3NestedObjec
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate L3 schema")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.obj3b.config.v1~"
-                    "x.test12._.app_config.v1~"
-                    "x.test12._.mobile_config.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.obj3b.config.v1~"
+            "x.test12._.app_config.v1~"
+            "x.test12._.mobile_config.v1~",
+            True,
+            "validate L3 schema",
         ),
     ]
 
@@ -1188,18 +1097,11 @@ class TestCaseTestOp12TypeDerivationValidation_3LevelHierarchy_Valid(HttpRunner)
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate level 2 schema")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.hierarchy.entity.v1~"
-                    "x.test12._.document.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.hierarchy.entity.v1~"
+            "x.test12._.document.v1~",
+            True,
+            "validate level 2 schema",
         ),
         Step(
             RunRequest("register level 3 schema")
@@ -1239,18 +1141,11 @@ class TestCaseTestOp12TypeDerivationValidation_3LevelHierarchy_Valid(HttpRunner)
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate level 3 schema")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.hierarchy.entity.v1~"
-                    "x.test12._.document.v1~x.test12._.article.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.hierarchy.entity.v1~"
+            "x.test12._.document.v1~x.test12._.article.v1~",
+            True,
+            "validate level 3 schema",
         ),
     ]
 
@@ -1314,17 +1209,10 @@ class TestCaseTestOp12TypeDerivationValidation_3LevelHierarchy_L3ViolatesL2(
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate level 2 schema")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.hier2.base.v1~x.test12._.medium.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.hier2.base.v1~x.test12._.medium.v1~",
+            True,
+            "validate level 2 schema",
         ),
         Step(
             RunRequest("register level 3 schema violating level 2")
@@ -1358,18 +1246,11 @@ class TestCaseTestOp12TypeDerivationValidation_3LevelHierarchy_L3ViolatesL2(
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate level 3 schema should fail")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.hier2.base.v1~"
-                    "x.test12._.medium.v1~x.test12._.bad_large.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", False)
+        _validate_type_schema(
+            "gts.x.test12.hier2.base.v1~"
+            "x.test12._.medium.v1~x.test12._.bad_large.v1~",
+            False,
+            "validate level 3 schema should fail",
         ),
     ]
 
@@ -1439,17 +1320,10 @@ class TestCaseTestOp12TypeDerivationValidation_3LevelHierarchy_L3ViolatesL1(
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate level 2 schema")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.hier3.root.v1~x.test12._.branch.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.hier3.root.v1~x.test12._.branch.v1~",
+            True,
+            "validate level 2 schema",
         ),
         Step(
             RunRequest("register level 3 schema violating level 1")
@@ -1487,18 +1361,11 @@ class TestCaseTestOp12TypeDerivationValidation_3LevelHierarchy_L3ViolatesL1(
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate level 3 schema should fail")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.hier3.root.v1~"
-                    "x.test12._.branch.v1~x.test12._.bad_leaf.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", False)
+        _validate_type_schema(
+            "gts.x.test12.hier3.root.v1~"
+            "x.test12._.branch.v1~x.test12._.bad_leaf.v1~",
+            False,
+            "validate level 3 schema should fail",
         ),
     ]
 
@@ -1557,17 +1424,10 @@ class TestCaseTestOp12TypeDerivationValidation_3LevelHierarchy_ConstraintCascade
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate level 2 schema")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.cascade.message.v1~x.test12._.sms.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.cascade.message.v1~x.test12._.sms.v1~",
+            True,
+            "validate level 2 schema",
         ),
         Step(
             RunRequest("register level 3 schema with max 256")
@@ -1600,18 +1460,11 @@ class TestCaseTestOp12TypeDerivationValidation_3LevelHierarchy_ConstraintCascade
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate level 3 schema")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.cascade.message.v1~"
-                    "x.test12._.sms.v1~x.test12._.short_sms.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.cascade.message.v1~"
+            "x.test12._.sms.v1~x.test12._.short_sms.v1~",
+            True,
+            "validate level 3 schema",
         ),
     ]
 
@@ -1667,18 +1520,11 @@ class TestCaseTestOp12TypeDerivationValidation_3LevelHierarchy_InvalidCascade(
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate level 2 schema")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.badcascade.field.v1~"
-                    "x.test12._.medium.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.badcascade.field.v1~"
+            "x.test12._.medium.v1~",
+            True,
+            "validate level 2 schema",
         ),
         Step(
             RunRequest("register level 3 schema with max 256")
@@ -1708,18 +1554,11 @@ class TestCaseTestOp12TypeDerivationValidation_3LevelHierarchy_InvalidCascade(
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate level 3 schema should fail")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.badcascade.field.v1~"
-                    "x.test12._.medium.v1~x.test12._.bad_large.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", False)
+        _validate_type_schema(
+            "gts.x.test12.badcascade.field.v1~"
+            "x.test12._.medium.v1~x.test12._.bad_large.v1~",
+            False,
+            "validate level 3 schema should fail",
         ),
         Step(
             RunRequest("validate level 3 schema should fail")
@@ -1817,18 +1656,11 @@ class TestCaseTestOp12_TypeChangeIntNumberInt(HttpRunner):
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate L2 schema should fail - widens type")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.typechange.score.v1~"
-                    "x.test12._.float_score.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", False)
+        _validate_type_schema(
+            "gts.x.test12.typechange.score.v1~"
+            "x.test12._.float_score.v1~",
+            False,
+            "validate L2 schema should fail - widens type",
         ),
         Step(
             RunRequest("register L3 schema narrowing back to integer")
@@ -1859,19 +1691,12 @@ class TestCaseTestOp12_TypeChangeIntNumberInt(HttpRunner):
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate L3 schema should also fail")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.typechange.score.v1~"
-                    "x.test12._.float_score.v1~"
-                    "x.test12._.int_score.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", False)
+        _validate_type_schema(
+            "gts.x.test12.typechange.score.v1~"
+            "x.test12._.float_score.v1~"
+            "x.test12._.int_score.v1~",
+            False,
+            "validate L3 schema should also fail",
         ),
     ]
 
@@ -1932,7 +1757,7 @@ class TestCaseTestOp12_TypeChangeStringToInt(HttpRunner):
             }},
             "register L2 changing string to integer",
         ),
-        _validate_type(
+        _validate_type_schema(
             ("gts.x.test12.typebreak.record.v1~"
              "x.test12._.bad_record.v1~"),
             False, "validate L2 should fail",
@@ -2053,7 +1878,7 @@ class TestCaseTestOp12_RequiredSubsetInOverlay(HttpRunner):
             },
             "register L2 with subset required",
         ),
-        _validate_type(
+        _validate_type_schema(
             ("gts.x.test12.reqsub.contact.v1~"
              "x.test12._.slim_contact.v1~"),
             True, "validate L2 should pass",
@@ -2087,7 +1912,7 @@ class TestCaseTestOp12_PatternConflict(HttpRunner):
             }},
             "register L2 with numeric pattern",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test12.pattern.code.v1~x.test12._.num_code.v1~",
             False, "validate L2 should fail",
         ),
@@ -2202,18 +2027,11 @@ class TestCaseTestOp12_ArrayTypeChange(HttpRunner):
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate L2 schema")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.arrtype.tags.v1~"
-                    "x.test12._.short_tags.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", True)
+        _validate_type_schema(
+            "gts.x.test12.arrtype.tags.v1~"
+            "x.test12._.short_tags.v1~",
+            True,
+            "validate L2 schema",
         ),
         Step(
             RunRequest("register L3 schema changing items to integer")
@@ -2249,19 +2067,12 @@ class TestCaseTestOp12_ArrayTypeChange(HttpRunner):
             .validate()
             .assert_equal("status_code", 200)
         ),
-        Step(
-            RunRequest("validate L3 schema should fail")
-            .post("/validate-type")
-            .with_json({
-                "type_id": (
-                    "gts.x.test12.arrtype.tags.v1~"
-                    "x.test12._.short_tags.v1~"
-                    "x.test12._.bad_tags.v1~"
-                )
-            })
-            .validate()
-            .assert_equal("status_code", 200)
-            .assert_equal("body.ok", False)
+        _validate_type_schema(
+            "gts.x.test12.arrtype.tags.v1~"
+            "x.test12._.short_tags.v1~"
+            "x.test12._.bad_tags.v1~",
+            False,
+            "validate L3 schema should fail",
         ),
     ]
 
@@ -2401,7 +2212,7 @@ class TestCaseTestOp12_AdditionalPropertiesLoosened(HttpRunner):
             },
             "register derived setting AP true",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test12.ap.loose.v1~x.test12._.opened.v1~",
             False, "validate should fail - AP loosened",
         ),
@@ -2432,7 +2243,7 @@ class TestCaseTestOp12_AdditionalPropertiesOmitted(HttpRunner):
             },
             "register derived omitting AP",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test12.ap.omit.v1~x.test12._.no_ap.v1~",
             False, "validate should fail - AP omitted",
         ),
@@ -2468,7 +2279,7 @@ class TestCaseTestOp12_RequiredDroppedViaEmptyRequired(HttpRunner):
             },
             "register derived with empty required",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test12.req.drop.v1~x.test12._.empty_req.v1~",
             True, "validate should pass - empty overlay is ok",
         ),
@@ -2508,7 +2319,7 @@ class TestCaseTestOp12_RequiredFieldRemoval(HttpRunner):
             },
             "register derived removing required email",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test12.req.rm.v1~x.test12._.less_req.v1~",
             True, "validate should pass - allOf union keeps all",
         ),
@@ -2566,7 +2377,7 @@ class TestCaseTestOp12_EnumValueReplacement(HttpRunner):
             }},
             "register derived with enum [a, d]",
         ),
-        _validate_type(
+        _validate_type_schema(
             ("gts.x.test12.enumrepl.item.v1~"
              "x.test12._.replaced.v1~"),
             False,
@@ -2606,7 +2417,7 @@ class TestCaseTestOp12_RequiredPropertyGainsNullability(HttpRunner):
             }},
             "register derived allowing null for name",
         ),
-        _validate_type(
+        _validate_type_schema(
             ("gts.x.test12.nullable.rec.v1~"
              "x.test12._.null_name.v1~"),
             False,
@@ -2645,7 +2456,7 @@ class TestCaseTestOp12_PrimitiveTypeWidening(HttpRunner):
             }},
             "register derived widening to [string, number]",
         ),
-        _validate_type(
+        _validate_type_schema(
             ("gts.x.test12.typewiden.field.v1~"
              "x.test12._.wider.v1~"),
             False,
@@ -2690,7 +2501,7 @@ class TestCaseTestOp12_ConstViolatesMinimum(HttpRunner):
             }},
             "register derived with const 32",
         ),
-        _validate_type(
+        _validate_type_schema(
             ("gts.x.test12.constmin.val.v1~"
              "x.test12._.bad_const.v1~"),
             False,
@@ -3332,7 +3143,7 @@ class TestCaseOp12_CyclingRef_SelfReference(HttpRunner):
             },
             "register derived that refs itself",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test12.cycle.self.v1~"
                 "x.test12._.self_ref.v1~"
@@ -3400,7 +3211,7 @@ class TestCaseOp12_CyclingRef_TwoNodeCycle(HttpRunner):
             },
             "register node B referencing node A",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test12.cycle2.base.v1~"
                 "x.test12._.node_a.v1~"
@@ -3408,7 +3219,7 @@ class TestCaseOp12_CyclingRef_TwoNodeCycle(HttpRunner):
             False,
             "validate node A should fail - two-node cycle",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test12.cycle2.base.v1~"
                 "x.test12._.node_b.v1~"
@@ -3495,7 +3306,7 @@ class TestCaseOp12_CyclingRef_ThreeNodeCycle(HttpRunner):
             },
             "register node C referencing node A",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test12.cycle3.base.v1~"
                 "x.test12._.node_a.v1~"
@@ -3503,7 +3314,7 @@ class TestCaseOp12_CyclingRef_ThreeNodeCycle(HttpRunner):
             False,
             "validate node A should fail - three-node cycle",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test12.cycle3.base.v1~"
                 "x.test12._.node_b.v1~"
@@ -3511,7 +3322,7 @@ class TestCaseOp12_CyclingRef_ThreeNodeCycle(HttpRunner):
             False,
             "validate node B should fail - three-node cycle",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test12.cycle3.base.v1~"
                 "x.test12._.node_c.v1~"
@@ -3531,12 +3342,16 @@ class TestCaseOp12_FinalBase_RejectDerived(HttpRunner):
     """OP#12 / x-gts-final: Derived schema from a final base MUST fail validation.
 
     Base type declares x-gts-final: true. A derived schema referencing it
-    via allOf/$ref MUST be rejected by /validate-type.
+    via allOf/$ref MUST be rejected by /validate-type-schema.
     """
 
     config = Config("OP#12 x-gts-final: reject derived from final base").base_url(
         get_gts_base_url()
     )
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.test12.final.base.v1~",
@@ -3560,7 +3375,7 @@ class TestCaseOp12_FinalBase_RejectDerived(HttpRunner):
             },
             "register derived from final base",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test12.final.base.v1~x.test12._.derived.v1~",
             False,
             "validate derived from final base should fail",
@@ -3577,6 +3392,10 @@ class TestCaseOp12_FinalMidChain(HttpRunner):
     config = Config("OP#12 x-gts-final: mid-chain final blocks derivation").base_url(
         get_gts_base_url()
     )
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.test12.finalmid.base.v1~",
@@ -3611,7 +3430,7 @@ class TestCaseOp12_FinalMidChain(HttpRunner):
             },
             "register leaf C from final B",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test12.finalmid.base.v1~x.test12._.mid.v1~x.test12._.leaf.v1~",
             False,
             "validate C should fail - B is final",
@@ -3628,6 +3447,10 @@ class TestCaseOp12_FinalSiblingUnaffected(HttpRunner):
     config = Config("OP#12 x-gts-final: sibling of final is unaffected").base_url(
         get_gts_base_url()
     )
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.test12.finalsib.base.v1~",
@@ -3659,7 +3482,7 @@ class TestCaseOp12_FinalSiblingUnaffected(HttpRunner):
             },
             "register C (sibling) from A",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test12.finalsib.base.v1~x.test12._.sibling_c.v1~",
             True,
             "validate C should pass - A is not final",
@@ -3668,7 +3491,7 @@ class TestCaseOp12_FinalSiblingUnaffected(HttpRunner):
 
 
 class TestCaseOp12_FinalBase_SelfValidationPasses(HttpRunner):
-    """OP#12 / x-gts-final: A final base type itself MUST pass /validate-type.
+    """OP#12 / x-gts-final: A final base type itself MUST pass /validate-type-schema.
 
     The final modifier restricts derivation, not the type's own validity.
     """
@@ -3676,6 +3499,10 @@ class TestCaseOp12_FinalBase_SelfValidationPasses(HttpRunner):
     config = Config("OP#12 x-gts-final: final base self-validation passes").base_url(
         get_gts_base_url()
     )
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.test12.finalself.base.v1~",
@@ -3688,7 +3515,7 @@ class TestCaseOp12_FinalBase_SelfValidationPasses(HttpRunner):
             },
             "register final base schema",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test12.finalself.base.v1~",
             True,
             "validate final base itself should pass",

--- a/tests/test_op13_schema_traits_validation.py
+++ b/tests/test_op13_schema_traits_validation.py
@@ -3,7 +3,7 @@ from .helpers.http_run_helpers import (
     register as _register,
     register_derived as _register_derived,
     validate_entity as _validate_entity,
-    validate_type as _validate_type,
+    validate_type_schema as _validate_type_schema,
 )
 from httprunner import HttpRunner, Config
 
@@ -65,7 +65,7 @@ class TestCaseOp13_TraitsValid_AllResolved(HttpRunner):
             },
             "register derived with all traits resolved",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.traits.event.v1~x.test13._.order_event.v1~",
             True,
             "validate derived - all traits resolved",
@@ -120,7 +120,7 @@ class TestCaseOp13_TraitsValid_DefaultsUsed(HttpRunner):
             },
             "register derived with no x-gts-traits (rely on defaults)",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.dfl.event.v1~x.test13._.simple_event.v1~",
             True,
             "validate derived - defaults fill all traits",
@@ -178,7 +178,7 @@ class TestCaseOp13_TraitsInvalid_MissingRequired(HttpRunner):
             },
             "register derived missing topicRef trait",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.miss.event.v1~x.test13._.incomplete.v1~",
             False,
             "validate should fail - topicRef not resolved",
@@ -234,7 +234,7 @@ class TestCaseOp13_TraitsInvalid_WrongType(HttpRunner):
             },
             "register derived with wrong type for maxRetries",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.wtype.event.v1~x.test13._.bad_type.v1~",
             False,
             "validate should fail - maxRetries is not integer",
@@ -288,7 +288,7 @@ class TestCaseOp13_TraitsInvalid_UnknownProperty(HttpRunner):
             },
             "register derived with unknown trait property",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.unk.event.v1~x.test13._.extra_trait.v1~",
             False,
             "validate should fail - unknownTrait not in schema",
@@ -352,7 +352,7 @@ class TestCaseOp13_TraitsValid_PartialOverride(HttpRunner):
             },
             "register derived overriding only topicRef",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.part.event.v1~x.test13._.partial.v1~",
             True,
             "validate - topicRef overridden, retention uses default",
@@ -420,7 +420,7 @@ class TestCaseOp13_TraitsValid_BothKeywordsInSameSchema(HttpRunner):
             },
             "register mid-level with both keywords",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.both.event.v1~x.test13._.audit.v1~",
             True,
             "validate mid-level - topicRef resolved, retention has default",
@@ -440,7 +440,7 @@ class TestCaseOp13_TraitsValid_BothKeywordsInSameSchema(HttpRunner):
             },
             "register leaf resolving auditRetention",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.both.event.v1~"
                 "x.test13._.audit.v1~"
@@ -517,7 +517,7 @@ class TestCaseOp13_TraitsInvalid_3Level_MissingInLeaf(HttpRunner):
             },
             "register leaf missing priority trait",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.l3miss.event.v1~"
                 "x.test13._.mid.v1~"
@@ -567,7 +567,7 @@ class TestCaseOp13_TraitsInvalid_OverrideInChain(HttpRunner):
             },
             "register mid-level setting retention=P30D",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.ovr.event.v1~x.test13._.mid_ovr.v1~",
             True,
             "validate mid-level",
@@ -587,7 +587,7 @@ class TestCaseOp13_TraitsInvalid_OverrideInChain(HttpRunner):
             },
             "register leaf overriding retention=P365D",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.ovr.event.v1~"
                 "x.test13._.mid_ovr.v1~"
@@ -656,7 +656,7 @@ class TestCaseOp13_TraitsInvalid_OverrideTopicRef3Level(HttpRunner):
             },
             "register mid-level setting topicRef=audit",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.ovt.event.v1~"
                 "x.test13._.audit_evt.v1~"
@@ -685,7 +685,7 @@ class TestCaseOp13_TraitsInvalid_OverrideTopicRef3Level(HttpRunner):
             },
             "register leaf overriding topicRef=notification",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.ovt.event.v1~"
                 "x.test13._.audit_evt.v1~"
@@ -761,7 +761,7 @@ class TestCaseOp13_TraitsInvalid_ChangeDefaultInMid(HttpRunner):
             },
             "register mid changing retention default to P90D",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.chdfl.event.v1~"
                 "x.test13._.chdfl_mid.v1~"
@@ -823,7 +823,7 @@ class TestCaseOp13_TraitsInvalid_ConstraintViolation(HttpRunner):
             },
             "register derived with invalid enum value",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.enum.event.v1~x.test13._.bad_enum.v1~",
             False,
             "validate should fail - priority not in enum",
@@ -978,7 +978,7 @@ class TestCaseOp13_TraitsValid_BaseSchemaNoTraits(HttpRunner):
             },
             "register derived without traits",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.notr.event.v1~x.test13._.plain.v1~",
             True,
             "validate - no traits to check, should pass",
@@ -1030,7 +1030,7 @@ class TestCaseOp13_TraitsInvalid_MinimumViolation(HttpRunner):
             },
             "register derived with negative maxRetries",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.minv.event.v1~x.test13._.neg_retry.v1~",
             False,
             "validate should fail - maxRetries below minimum",
@@ -1126,7 +1126,7 @@ class TestCaseOp13_TraitsValid_RefBasedTraitSchema(HttpRunner):
             },
             "register derived resolving $ref traits",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.ref.event.v1~"
                 "x.test13._.ref_leaf.v1~"
@@ -1222,7 +1222,7 @@ class TestCaseOp13_TraitsInvalid_RefBasedMissingTrait(HttpRunner):
             },
             "register derived missing topicRef from $ref trait",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.refm.event.v1~"
                 "x.test13._.ref_incomplete.v1~"
@@ -1294,7 +1294,7 @@ class TestCaseOp13_TraitsValid_NarrowingInDerived(HttpRunner):
             },
             "register mid-level narrowing priority to enum",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.narrow.event.v1~"
                 "x.test13._.mid_narrow.v1~"
@@ -1321,7 +1321,7 @@ class TestCaseOp13_TraitsValid_NarrowingInDerived(HttpRunner):
             },
             "register leaf with valid narrowed priority",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.narrow.event.v1~"
                 "x.test13._.mid_narrow.v1~"
@@ -1410,7 +1410,7 @@ class TestCaseOp13_TraitsInvalid_NarrowingViolation(HttpRunner):
             },
             "register leaf with value outside narrowed enum",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.nv.event.v1~"
                 "x.test13._.mid_nv.v1~"
@@ -1468,7 +1468,7 @@ class TestCaseOp13_TraitsValid_DefaultsFromRefSchema(HttpRunner):
             },
             "register derived with no traits (rely on $ref default)",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.refd.event.v1~"
                 "x.test13._.default_ref.v1~"
@@ -1529,7 +1529,7 @@ class TestCaseOp13_TraitsInvalid_APBlocksExtension(HttpRunner):
             },
             "register mid-level that extends trait schema with topicRef",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.ap.event.v1~x.test13._.ap_mid.v1~",
             False,
             (
@@ -1574,7 +1574,7 @@ class TestCaseOp13_TraitsInvalid_DerivedHasTraitsButNoTraitSchema(HttpRunner):
             },
             "register derived with x-gts-traits but no traits-schema",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.nt0.event.v1~x.test13._.derived_has_traits.v1~",
             False,
             "validate should fail - trait values have no trait schema",
@@ -1605,7 +1605,7 @@ class TestCaseOp13_TraitsInvalid_BaseHasTraitsButNoTraitSchema(HttpRunner):
             },
             "register base with x-gts-traits but no traits-schema",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.nt1.event.v1~",
             False,
             "validate should fail - x-gts-traits without x-gts-traits-schema",
@@ -1653,7 +1653,7 @@ class TestCaseOp13_TraitsInvalid_ConstNarrowingViolationInLeaf(HttpRunner):
             },
             "register mid-level narrowing retention to const P30D",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.const.event.v1~x.test13._.mid_const.v1~",
             True,
             "validate mid-level - const narrowing",
@@ -1671,7 +1671,7 @@ class TestCaseOp13_TraitsInvalid_ConstNarrowingViolationInLeaf(HttpRunner):
             },
             "register leaf overriding retention to P90D",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.const.event.v1~"
                 "x.test13._.mid_const.v1~"
@@ -1723,7 +1723,7 @@ class TestCaseOp13_TraitsValid_ConstNarrowingLeafMatches(HttpRunner):
             },
             "register mid-level narrowing retention to const P30D",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.test13.constm.event.v1~x.test13._.mid_constm.v1~",
             True,
             "validate mid-level - const narrowing",
@@ -1741,7 +1741,7 @@ class TestCaseOp13_TraitsValid_ConstNarrowingLeafMatches(HttpRunner):
             },
             "register leaf with retention matching const P30D",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.constm.event.v1~"
                 "x.test13._.mid_constm.v1~"
@@ -1817,7 +1817,7 @@ class TestCaseOp13_TraitsInvalid_CyclingRef_SelfRef(HttpRunner):
             },
             "register derived with traits",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.cyc.selfevt.v1~"
                 "x.test13._.cyc_self_leaf.v1~"
@@ -1919,7 +1919,7 @@ class TestCaseOp13_TraitsInvalid_CyclingRef_TwoNode(HttpRunner):
             },
             "register derived with traits",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.cyc2.event.v1~"
                 "x.test13._.cyc2_leaf.v1~"
@@ -1967,7 +1967,7 @@ class TestCaseOp13_TraitsInvalid_TraitsSchemaNotObject(HttpRunner):
             },
             "register derived",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.tsnobj.event.v1~"
                 "x.test13._.tsnobj_leaf.v1~"
@@ -2026,7 +2026,7 @@ class TestCaseOp13_TraitsInvalid_TraitsInInstance(HttpRunner):
             },
             "register derived with traits",
         ),
-        _validate_type(
+        _validate_type_schema(
             (
                 "gts.x.test13.tinst.event.v1~"
                 "x.test13._.tinst_leaf.v1~"

--- a/tests/test_op6_schema_validation.py
+++ b/tests/test_op6_schema_validation.py
@@ -873,6 +873,10 @@ class TestCaseOp6_AbstractType_RejectWellKnownInstance(HttpRunner):
     config = Config("OP#6 x-gts-abstract: reject well-known instance of abstract type").base_url(
         get_gts_base_url()
     )
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         # Register abstract base schema
         Step(
@@ -927,6 +931,10 @@ class TestCaseOp6_AbstractType_RejectAnonInstance(HttpRunner):
     config = Config("OP#6 x-gts-abstract: reject anonymous instance of abstract type").base_url(
         get_gts_base_url()
     )
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         # Register abstract base schema
         Step(
@@ -984,6 +992,10 @@ class TestCaseOp6_AbstractType_AllowInstanceOfConcreteDerived(HttpRunner):
     config = Config("OP#6 x-gts-abstract: allow instance of concrete derived type").base_url(
         get_gts_base_url()
     )
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         # Register abstract base schema
         Step(
@@ -1060,6 +1072,10 @@ class TestCaseOp6_AbstractType_ValidateEntityRejectsInstance(HttpRunner):
     config = Config("OP#6 x-gts-abstract: validate-entity rejects instance of abstract type").base_url(
         get_gts_base_url()
     )
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         # Register abstract base schema
         Step(
@@ -1115,6 +1131,10 @@ class TestCaseOp6_AbstractType_RejectCombinedAnonInstance(HttpRunner):
     config = Config("OP#6 x-gts-abstract: reject combined anonymous instance of abstract type").base_url(
         get_gts_base_url()
     )
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         # Register abstract base schema
         Step(

--- a/tests/test_refimpl_x_gts_final_abstract.py
+++ b/tests/test_refimpl_x_gts_final_abstract.py
@@ -15,7 +15,7 @@ from .helpers.http_run_helpers import (
     register_instance as _register_instance,
     validate_entity as _validate_entity,
     validate_instance as _validate_instance,
-    validate_type as _validate_type,
+    validate_type_schema as _validate_type_schema,
 )
 from httprunner import HttpRunner, Config, Step, RunRequest
 
@@ -29,6 +29,10 @@ class TestCaseFinal_RejectDerivedSchema(HttpRunner):
     """x-gts-final: Derived schema from a final base MUST fail validation."""
 
     config = Config("final: reject derived schema").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.final.reject.v1~",
@@ -45,7 +49,7 @@ class TestCaseFinal_RejectDerivedSchema(HttpRunner):
             {"type": "object", "properties": {"extra": {"type": "string"}}},
             "register derived from final",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.testfa.final.reject.v1~x.testfa._.derived.v1~",
             False,
             "validate derived should fail",
@@ -57,6 +61,10 @@ class TestCaseFinal_AllowWellKnownInstance(HttpRunner):
     """x-gts-final: Well-known instances of a final type MUST pass validation."""
 
     config = Config("final: allow well-known instance").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.final.inst.v1~",
@@ -93,6 +101,10 @@ class TestCaseFinal_AllowAnonymousInstance(HttpRunner):
     """
 
     config = Config("final: allow anonymous instance").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.final.anon.v1~",
@@ -131,6 +143,10 @@ class TestCaseFinal_MidChainFinal(HttpRunner):
     """
 
     config = Config("final: mid-chain final blocks derivation").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.finalmid.base.v1~",
@@ -150,7 +166,7 @@ class TestCaseFinal_MidChainFinal(HttpRunner):
             {"type": "object", "properties": {"extra": {"type": "string"}}},
             "register leaf C from final B",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.testfa.finalmid.base.v1~x.testfa._.mid.v1~x.testfa._.leaf.v1~",
             False,
             "validate C should fail - B is final",
@@ -165,6 +181,10 @@ class TestCaseFinal_SiblingUnaffected(HttpRunner):
     """
 
     config = Config("final: sibling unaffected").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.finalsib.base.v1~",
@@ -184,7 +204,7 @@ class TestCaseFinal_SiblingUnaffected(HttpRunner):
             {"type": "object", "properties": {"extra": {"type": "string"}}},
             "register C (sibling) from A",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.testfa.finalsib.base.v1~x.testfa._.sibling_c.v1~",
             True,
             "validate C should pass - A is not final",
@@ -196,6 +216,10 @@ class TestCaseFinal_FalseIsNoop(HttpRunner):
     """x-gts-final: false behaves the same as absent — derivation allowed."""
 
     config = Config("final: false is noop").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.finalfalse.base.v1~",
@@ -212,7 +236,7 @@ class TestCaseFinal_FalseIsNoop(HttpRunner):
             {"type": "object"},
             "register derived from final=false base",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.testfa.finalfalse.base.v1~x.testfa._.derived.v1~",
             True,
             "validate derived should pass - final=false is noop",
@@ -227,6 +251,10 @@ class TestCaseFinal_NonBooleanRejected(HttpRunner):
     """
 
     config = Config("final: non-boolean rejected").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         Step(
             RunRequest("register schema with final='yes' should be rejected")
@@ -252,6 +280,10 @@ class TestCaseFinal_InInstanceRejected(HttpRunner):
     """
 
     config = Config("final: in instance rejected").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.finalininst.base.v1~",
@@ -289,6 +321,10 @@ class TestCaseAbstract_RejectDirectInstance(HttpRunner):
     """x-gts-abstract: Direct instance of abstract type MUST fail validation."""
 
     config = Config("abstract: reject direct instance").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.abs.reject.v1~",
@@ -323,6 +359,10 @@ class TestCaseAbstract_AllowDerivedSchema(HttpRunner):
     """x-gts-abstract: Derived schema from abstract type MUST pass validation."""
 
     config = Config("abstract: allow derived schema").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.abs.derive.v1~",
@@ -339,7 +379,7 @@ class TestCaseAbstract_AllowDerivedSchema(HttpRunner):
             {"type": "object", "properties": {"extra": {"type": "string"}}},
             "register concrete derived",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.testfa.abs.derive.v1~x.testfa._.concrete.v1~",
             True,
             "validate derived should pass",
@@ -354,6 +394,10 @@ class TestCaseAbstract_AllowInstanceOfConcreteDerived(HttpRunner):
     """
 
     config = Config("abstract: allow instance of concrete derived").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.abs.concinst.v1~",
@@ -398,6 +442,10 @@ class TestCaseAbstract_ChainOfAbstracts(HttpRunner):
     """
 
     config = Config("abstract: chain of abstracts").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.abs.chain.v1~",
@@ -454,6 +502,10 @@ class TestCaseAbstract_FalseIsNoop(HttpRunner):
     """x-gts-abstract: false behaves the same as absent — instances allowed."""
 
     config = Config("abstract: false is noop").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.absfalse.base.v1~",
@@ -481,6 +533,10 @@ class TestCaseAbstract_NonBooleanRejected(HttpRunner):
     """x-gts-abstract: Non-boolean value MUST be rejected on registration."""
 
     config = Config("abstract: non-boolean rejected").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         Step(
             RunRequest("register schema with abstract=1 should be rejected")
@@ -503,6 +559,10 @@ class TestCaseAbstract_InInstanceRejected(HttpRunner):
     """x-gts-abstract: Schema-only keyword in an instance MUST be rejected."""
 
     config = Config("abstract: in instance rejected").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.absininst.base.v1~",
@@ -533,6 +593,10 @@ class TestCaseAbstract_CombinedAnonInstanceRejected(HttpRunner):
     """x-gts-abstract: Combined anonymous instance of abstract type MUST fail."""
 
     config = Config("abstract: combined anon instance rejected").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.absanon.base.v1~",
@@ -572,6 +636,10 @@ class TestCaseFinal_RegistrationGuardRejectsDerived(HttpRunner):
     """x-gts-final: Registration with ?validate=true MUST reject derived from final base."""
 
     config = Config("final: registration guard rejects derived").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.finalreg.base.v1~",
@@ -605,6 +673,10 @@ class TestCaseAbstract_RegistrationGuardRejectsInstance(HttpRunner):
     """x-gts-abstract: Registration with ?validate=true MUST reject instance of abstract type."""
 
     config = Config("abstract: registration guard rejects instance").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.absreg.base.v1~",
@@ -646,6 +718,10 @@ class TestCaseFinal_InsideAllOfRejected(HttpRunner):
     """
 
     config = Config("final: inside allOf rejected").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.finalallof.base.v1~",
@@ -679,6 +755,10 @@ class TestCaseAbstract_InsideAllOfRejected(HttpRunner):
     """x-gts-abstract inside allOf MUST be rejected — keyword must be at top level."""
 
     config = Config("abstract: inside allOf rejected").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.absallof.base.v1~",
@@ -717,6 +797,10 @@ class TestCaseInteraction_BothModifiersRejected(HttpRunner):
     """Both x-gts-final and x-gts-abstract on same schema MUST be rejected on registration."""
 
     config = Config("interaction: both modifiers rejected").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         Step(
             RunRequest("register schema with both modifiers should be rejected")
@@ -744,6 +828,10 @@ class TestCaseInteraction_FinalWithTraitsFullyResolved(HttpRunner):
     """
 
     config = Config("interaction: final with traits fully resolved").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.finaltrait.base.v1~",
@@ -773,7 +861,7 @@ class TestCaseInteraction_FinalWithTraitsFullyResolved(HttpRunner):
             "register final derived with traits resolved",
             top_level={"x-gts-final": True},
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.testfa.finaltrait.base.v1~x.testfa._.leaf.v1~",
             True,
             "validate final with resolved traits should pass",
@@ -789,6 +877,10 @@ class TestCaseInteraction_FinalWithTraitsMissing(HttpRunner):
     """
 
     config = Config("interaction: final with missing traits").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.finalmiss.base.v1~",
@@ -815,7 +907,7 @@ class TestCaseInteraction_FinalWithTraitsMissing(HttpRunner):
             "register final derived without resolving traits",
             top_level={"x-gts-final": True},
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.testfa.finalmiss.base.v1~x.testfa._.leaf.v1~",
             False,
             "validate final with missing required traits should fail",
@@ -831,6 +923,10 @@ class TestCaseInteraction_AbstractWithIncompleteTraitsOk(HttpRunner):
     """
 
     config = Config("interaction: abstract with incomplete traits ok").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         _register(
             "gts://gts.x.testfa.abstrait.base.v1~",
@@ -849,7 +945,7 @@ class TestCaseInteraction_AbstractWithIncompleteTraitsOk(HttpRunner):
             },
             "register abstract base with required trait (no default)",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.testfa.abstrait.base.v1~",
             True,
             "validate abstract with incomplete traits should pass",
@@ -865,6 +961,10 @@ class TestCaseInteraction_AbstractBaseFinalDerived(HttpRunner):
     """
 
     config = Config("interaction: abstract base + final derived").base_url(get_gts_base_url())
+
+    def test_start(self):
+        super().test_start()
+
     teststeps = [
         # Register abstract base
         _register(
@@ -892,7 +992,7 @@ class TestCaseInteraction_AbstractBaseFinalDerived(HttpRunner):
             top_level={"x-gts-final": True},
         ),
         # B is valid as a schema
-        _validate_type(
+        _validate_type_schema(
             "gts.x.testfa.absfinal.base.v1~x.testfa._.concrete.v1~",
             True,
             "validate B should pass",
@@ -918,7 +1018,7 @@ class TestCaseInteraction_AbstractBaseFinalDerived(HttpRunner):
             {"type": "object"},
             "attempt to derive from final B",
         ),
-        _validate_type(
+        _validate_type_schema(
             "gts.x.testfa.absfinal.base.v1~x.testfa._.concrete.v1~x.testfa._.sub.v1~",
             False,
             "validate derived from final B should fail",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated specification to version 0.11 with terminology refinements.
  * Renamed type validation endpoint from `/validate-type` to `/validate-type-schema`.
  * Clarified GTS Type Schema terminology and registry structure throughout specification.

* **API Updates**
  * Updated endpoint naming and validation behavior to align with specification version 0.11 changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->