### PR TITLE
ci(release): publish gts-spec-tests image to ghcr.io on tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  # Keep SHA-pinned GitHub Actions fresh. Dependabot understands SHA pins with
+  # trailing version comments (e.g. `@<sha>  # v4`) and updates both the SHA
+  # and the comment together — same UX as tag-based references, without the
+  # supply-chain risk of mutable tags.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci(deps)"
+    # Roll all action bumps into a single PR per week to avoid PR spam across
+    # our small workflow set.
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/release-tests-image.yml
+++ b/.github/workflows/release-tests-image.yml
@@ -19,7 +19,12 @@ jobs:
     if: github.repository == 'GlobalTypeSystem/gts-spec'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # Defense in depth: don't leave the GITHUB_TOKEN in .git/config.
+          # The workflow doesn't currently upload artifacts or cache .git,
+          # but this guards against future modifications that might.
+          persist-credentials: false
 
       - name: Verify spec version matches tag
         run: |
@@ -62,13 +67,13 @@ jobs:
           fi
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -76,7 +81,7 @@ jobs:
 
       - name: Compute image tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ghcr.io/globaltypesystem/gts-spec-tests
           # `latest` is intentionally NOT set automatically: backport patches to
@@ -89,7 +94,7 @@ jobs:
             type=semver,pattern=v{{major}}.{{minor}}
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: tests
           file: tests/Dockerfile
@@ -99,7 +104,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           name: ${{ github.ref_name }}
           generate_release_notes: true

--- a/.github/workflows/release-tests-image.yml
+++ b/.github/workflows/release-tests-image.yml
@@ -1,0 +1,124 @@
+name: Release Tests Image
+
+# Publishes the gts-spec test runner image to GHCR on every semver tag.
+# Tag format: vMAJOR.MINOR.PATCH (e.g. v0.11.3).
+# MAJOR.MINOR must match the spec version declared in README.md.
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write   # create GitHub Release
+  packages: write   # push to ghcr.io
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Only publish from the canonical repository, never from forks.
+    if: github.repository == 'GlobalTypeSystem/gts-spec'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify spec version matches tag
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"          # v0.11.3 or v0.11.3-rc.1
+          VERSION="${TAG#v}"                      # 0.11.3   or 0.11.3-rc.1
+          # Extract leading "MAJOR.MINOR" — anchored at the start so any patch
+          # and/or prerelease suffix is ignored (e.g. 0.11.3-rc.1 -> 0.11).
+          MAJOR_MINOR=$(printf '%s' "$VERSION" | grep -oE '^[0-9]+\.[0-9]+' || true)
+          if [ -z "${MAJOR_MINOR:-}" ]; then
+            echo "::error::Tag $TAG does not start with MAJOR.MINOR"
+            exit 1
+          fi
+
+          # The canonical spec version is the machine-readable marker in README.md:
+          #   <!-- gts-spec-version: X.Y -->
+          # The human-readable "**VERSION**" line below it is for readers only and
+          # may be reworded freely.
+          SPEC_VERSION=$(grep -oE '<!-- gts-spec-version: [0-9]+\.[0-9]+ -->' README.md \
+            | grep -oE '[0-9]+\.[0-9]+')
+
+          if [ -z "${SPEC_VERSION:-}" ]; then
+            echo "::error file=README.md::Missing or malformed '<!-- gts-spec-version: X.Y -->' marker in README.md"
+            exit 1
+          fi
+
+          MARKER_COUNT=$(grep -cE '<!-- gts-spec-version: [0-9]+\.[0-9]+ -->' README.md)
+          if [ "$MARKER_COUNT" -ne 1 ]; then
+            echo "::error file=README.md::Expected exactly one gts-spec-version marker in README.md, found $MARKER_COUNT"
+            exit 1
+          fi
+
+          echo "Tag:                  $TAG"
+          echo "Tag major.minor:      $MAJOR_MINOR"
+          echo "README spec version:  $SPEC_VERSION"
+
+          if [ "$MAJOR_MINOR" != "$SPEC_VERSION" ]; then
+            echo "::error::Tag $TAG (major.minor=$MAJOR_MINOR) does not match README spec version $SPEC_VERSION"
+            exit 1
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/globaltypesystem/gts-spec-tests
+          # `latest` is intentionally NOT set automatically: backport patches to
+          # older spec lines (e.g. v0.9.4 cut from release/v0.9 while main is at
+          # 0.11) would otherwise silently move `latest` backwards. Consumers
+          # should pin to `vX.Y.Z` for reproducibility or use the rolling
+          # `vX.Y` tag for the freshest patch of a given spec version.
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: tests
+          file: tests/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          body: |
+            Docker image for the GTS specification e2e test runner.
+
+            ```
+            docker pull ghcr.io/globaltypesystem/gts-spec-tests:${{ github.ref_name }}
+            ```
+
+            Run against a server reachable from the container (Mac/Docker Desktop):
+            ```
+            docker run --rm ghcr.io/globaltypesystem/gts-spec-tests:${{ github.ref_name }} \
+              --gts-base-url http://host.docker.internal:8000
+            ```
+
+            Linux hosts:
+            ```
+            docker run --rm --add-host=host.docker.internal:host-gateway \
+              ghcr.io/globaltypesystem/gts-spec-tests:${{ github.ref_name }} \
+              --gts-base-url http://host.docker.internal:8000
+            ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,3 +116,36 @@ Specification development guidelines:
 - Validate schemas against JSON Schema Draft 7 or later
 - Include both GTS Type Schemas (the canonical JSON definitions of types) and GTS Instance examples
 - Document any deviations or implementation-specific choices
+
+## Releases
+
+The specification version is declared in `README.md` via a machine-readable marker on the first line:
+
+```html
+<!-- gts-spec-version: X.Y -->
+```
+
+This marker is the canonical source of truth and is parsed by CI. The visible `> **VERSION**: ...` line below it is for human readers only and may be reworded freely, but its `X.Y` value MUST match the marker. When bumping the spec version, update both lines in the same change.
+
+A versioned Docker image of the conformance test suite is published to GHCR on every git tag matching `vX.Y.Z`, where:
+
+- `X.Y` MUST match the spec version declared in `README.md`. The release workflow enforces this and will fail the build on mismatch.
+- `Z` increments independently for changes to the test suite itself (additions, fixes, refactors) within the same spec version.
+
+When the specification moves to the next minor version (e.g. `0.11` → `0.12`), the README version line is updated in the same change, and the next release tag starts at `vX.Y.0`.
+
+### Cutting a release (maintainers only)
+
+Releases are produced from `github.com/GlobalTypeSystem/gts-spec`. The workflow is restricted to that repository; pushing a tag from a fork has no effect.
+
+```bash
+git tag v0.11.3
+git push origin v0.11.3
+```
+
+The [`Release Tests Image`](.github/workflows/release-tests-image.yml) workflow:
+
+1. Verifies the tag's `major.minor` matches the spec version in `README.md`.
+2. Builds the test runner image for `linux/amd64` and `linux/arm64`.
+3. Pushes it to `ghcr.io/globaltypesystem/gts-spec-tests` with two tags: the exact release `vX.Y.Z` and the rolling per-spec-version `vX.Y`. No floating `latest` tag is published — see `tests/README.md` for the rationale and consumer-side tag selection guidance.
+4. Creates a GitHub Release with auto-generated notes.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- gts-spec-version: 0.11 -->
 > **VERSION**: GTS specification draft, version 0.11
 
 # Global Type System (GTS) Specification

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,15 +5,20 @@
 # to be reachable from the container (e.g. via host.docker.internal when the
 # server runs on the Docker host).
 #
+# A pre-built image is published to GHCR for every release; rebuild locally
+# only when iterating on the tests themselves. See tests/README.md for the
+# tag selection guide (no `latest` tag is published — pin to vX.Y or vX.Y.Z):
+#   docker pull ghcr.io/globaltypesystem/gts-spec-tests:v0.11
+#
 # Build (from the gts-spec repo root):
-#   docker build -t gts-spec-e2e -f tests/Dockerfile tests
+#   docker build -t gts-spec-tests -f tests/Dockerfile tests
 #
 # Run against a server on the host (Mac/Docker Desktop):
-#   docker run --rm gts-spec-e2e --gts-base-url http://host.docker.internal:8000
+#   docker run --rm gts-spec-tests --gts-base-url http://host.docker.internal:8000
 #
 # Run against a server on the host (Linux — host.docker.internal not built-in):
 #   docker run --rm --add-host=host.docker.internal:host-gateway \
-#       gts-spec-e2e --gts-base-url http://host.docker.internal:8000
+#       gts-spec-tests --gts-base-url http://host.docker.internal:8000
 
 FROM python:3.12-slim
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -51,6 +51,49 @@ This approach provides:
 
 ## Running the tests
 
+### With Docker (recommended)
+
+A pre-built image is published to the GitHub Container Registry on every release. The image tag tracks the specification version: `vMAJOR.MINOR` matches the spec, and the `PATCH` segment increments on test-suite changes (e.g. `v0.11.3` runs against spec `0.11`).
+
+Pick the tag that fits your use case:
+
+- `vX.Y.Z` — exact release (e.g. `v0.11.3`). Recommended for CI / reproducible runs.
+- `vX.Y` — rolling tag for the freshest patch of a given spec version (e.g. `v0.11`). Recommended for interactive use when you want to validate against a specific spec version.
+
+> There is no `latest` tag. Multiple spec versions can be maintained in parallel (e.g. a `v0.9.x` backport patch while main is at `0.11`), and a single floating `latest` would not have an unambiguous meaning. Always pin to either `vX.Y.Z` or `vX.Y`.
+
+```bash
+# Start your server on the host (port 8000 in this example)
+<your-server-start-command>
+
+# Run the test suite from the published image (Mac/Docker Desktop)
+docker run --rm ghcr.io/globaltypesystem/gts-spec-tests:v0.11 \
+    --gts-base-url http://host.docker.internal:8000
+
+# Linux hosts (host.docker.internal is not built-in)
+docker run --rm --add-host=host.docker.internal:host-gateway \
+    ghcr.io/globaltypesystem/gts-spec-tests:v0.11 \
+    --gts-base-url http://host.docker.internal:8000
+
+# Pin to an exact release for reproducible CI runs
+docker run --rm ghcr.io/globaltypesystem/gts-spec-tests:v0.11.3 \
+    --gts-base-url http://host.docker.internal:8000
+
+# Run a specific test file or pytest selector
+docker run --rm ghcr.io/globaltypesystem/gts-spec-tests:v0.11 \
+    --gts-base-url http://host.docker.internal:8000 \
+    test_op1_id_validation.py
+```
+
+To rebuild the image locally while iterating on tests:
+
+```bash
+docker build -t gts-spec-tests -f tests/Dockerfile tests
+docker run --rm gts-spec-tests --gts-base-url http://host.docker.internal:8000
+```
+
+### With Python
+
 ```bash
 # Start your server on 8000 port
 <your-server-start-command>
@@ -70,8 +113,6 @@ GTS_BASE_URL=http://127.0.0.1:8001 pytest
 # or set it persistently
 export GTS_BASE_URL=http://127.0.0.1:8001
 pytest
-```
-
 ```
 
 ## Implemented test cases


### PR DESCRIPTION
- Add release-tests-image workflow that publishes the e2e test runner to ghcr.io/globaltypesystem/gts-spec-tests on every vX.Y.Z tag.
- Enforce that the tag's major.minor matches the spec version in README.md; release only from the canonical GlobalTypeSystem/gts-spec repo; build multi-arch (linux/amd64, linux/arm64); produce vX.Y.Z and vX.Y tags; create a GitHub Release with auto-generated notes.
- Document the published image in tests/README.md (pull/run/pin) and the release process in CONTRIBUTING.md.
- Align Dockerfile header comments with the published image name and point users at the GHCR image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced contributing guide with release process and versioning requirements
  * Expanded test running guide with Docker workflow examples and image publishing details
  * Added specification version marker to README

* **Chores**
  * Implemented automated GitHub Actions workflow for publishing multi-architecture test Docker images to GitHub Container Registry on version releases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlobalTypeSystem/gts-spec/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->