### PR TITLE
test: expect embedded UUID tails in OP5

### DIFF
--- a/tests/test_op5_id_uuid.py
+++ b/tests/test_op5_id_uuid.py
@@ -83,7 +83,7 @@ class TestCaseTestOp5IdToUuid_Instance(HttpRunner):
                     "7a1d2f34-5678-49ab-9012-abcdef123456"
                 ),
             )
-            .assert_equal("body.uuid", "4a31b759-722b-5bb1-a1dc-2cf40963e81b")
+            .assert_equal("body.uuid", "7a1d2f34-5678-49ab-9012-abcdef123456")
         ),
         Step(
             RunRequest("uuid mapping deterministic (instance)")


### PR DESCRIPTION
- Update the combined anonymous instance UUID expectation to preserve the explicit UUID tail returned by GTS implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an expected UUID value in one test case to match the current behavior for combined anonymous instance mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->