### PR TITLE
examples: update examples for 'settings' GTS types and instances

### DIFF
--- a/examples/settings/instances/gts.x.core.settings.type.v1~x.platform._.feature_new_dashboard.v1~.examples.jsonc
+++ b/examples/settings/instances/gts.x.core.settings.type.v1~x.platform._.feature_new_dashboard.v1~.examples.jsonc
@@ -3,7 +3,6 @@
   {
     "type": "gts.x.core.settings.type.v1~x.platform._.feature_new_dashboard.v1~",
     "tenant_id": "00000000-0000-0000-0000-000000000000",
-    "data_classification": "public",
     "value": {
       "enabled": false
     }
@@ -12,7 +11,6 @@
   {
     "type": "gts.x.core.settings.type.v1~x.platform._.feature_new_dashboard.v1~",
     "tenant_id": "00000000-0000-0000-0000-000000000000",
-    "data_classification": "public",
     "value": {
       "enabled": true
     }
@@ -22,7 +20,6 @@
   {
     "type": "gts.x.core.settings.type.v1~x.platform._.feature_new_dashboard.v1~",
     "tenant_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    "data_classification": "public",
     "value": {
       "enabled": false
     }
@@ -32,7 +29,6 @@
   {
     "type": "gts.x.core.settings.type.v1~x.platform._.feature_new_dashboard.v1~",
     "tenant_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    "data_classification": "public",
     "subject_type": "gts.x.core.idp.user.v1~",
     "subject_id": "f0e1d2c3-b4a5-6789-0123-456789abcdef",
     "value": {

--- a/examples/settings/instances/gts.x.core.settings.type.v1~x.platform._.maintenance_mode.v1~.examples.jsonc
+++ b/examples/settings/instances/gts.x.core.settings.type.v1~x.platform._.maintenance_mode.v1~.examples.jsonc
@@ -4,7 +4,6 @@
   {
     "type": "gts.x.core.settings.type.v1~x.platform._.maintenance_mode.v1~",
     "tenant_id": "00000000-0000-0000-0000-000000000000",
-    "data_classification": "public",
     "value": {
       "enabled": false
     }
@@ -13,7 +12,6 @@
   {
     "type": "gts.x.core.settings.type.v1~x.platform._.maintenance_mode.v1~",
     "tenant_id": "00000000-0000-0000-0000-000000000000",
-    "data_classification": "public",
     "value": {
       "enabled": true
     }

--- a/examples/settings/types/gts.x.core.settings.type.v1~.schema.json
+++ b/examples/settings/types/gts.x.core.settings.type.v1~.schema.json
@@ -3,9 +3,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "x-gts-abstract": true,
   "title": "Setting Envelope (Base)",
-  "description": "Abstract base type for all settings in the platform Settings Service. Defines the common envelope fields (type, tenant, subject, data classification) and an open 'value' container that derived types constrain to the concrete shape required by each setting.",
+  "description": "Abstract base type for all settings in the platform Settings Service. Defines the common envelope fields (type, tenant, subject) and an open 'value' container that derived types constrain to the concrete shape required by each setting.",
   "type": "object",
-  "required": ["type", "tenant_id", "data_classification", "value"],
+  "required": ["type", "tenant_id", "value"],
   "properties": {
     "type": {
       "description": "GTS Type Identifier of this setting.",
@@ -16,11 +16,6 @@
       "description": "UUID of the tenant scope this setting value belongs to.",
       "type": "string",
       "format": "uuid"
-    },
-    "data_classification": {
-      "description": "Data-sensitivity classification of this setting value. 'public': no special handling. 'pii': visible unmasked only to callers authorized for PII; masked otherwise. 'secret': encrypted at rest, masked on all administrative/human paths, plaintext only via the machine-only runtime SDK.",
-      "type": "string",
-      "enum": ["public", "pii", "secret"]
     },
     "subject_type": {
       "description": "GTS type of the object the setting belongs to (e.g. tenant, user, integration, host). When absent the subject is the tenant itself and subject_id is implied to equal tenant_id.",
@@ -40,7 +35,7 @@
   "additionalProperties": false,
   "x-gts-traits-schema": {
     "type": "object",
-    "required": ["scope_class"],
+    "required": ["scope_class", "data_classification"],
     "properties": {
       "scope_class": {
         "description": "Determines override and cascade behaviour. 'global': value lives only at platform scope, never tenant-overridable or inherited. 'cascading': value inherits down the tenant scope hierarchy with overrides at permitted scopes. 'local': value applies only at the scope where set, never inherited by descendants.",
@@ -62,6 +57,12 @@
         "description": "Whether a tenant administrator may set their own override for this setting. Has no effect when scope_class is 'global' (global settings are never tenant-overridable).",
         "type": "boolean",
         "default": false
+      },
+      "data_classification": {
+        "description": "Data-sensitivity classification of setting values of this type. 'public': no special handling. 'pii': visible unmasked only to callers authorized for PII; masked otherwise. 'secret': encrypted at rest, masked on all administrative/human paths, plaintext only via the machine-only runtime SDK.",
+        "type": "string",
+        "enum": ["public", "pii", "secret"],
+        "default": "public"
       },
       "domain_affinity": {
         "description": "Optional administrative domain binding (e.g. 'infrastructure', 'commercial'). When set, the settings hub filters by the administrator's current domain.",

--- a/examples/settings/types/gts.x.core.settings.type.v1~x.platform._.feature_new_dashboard.v1~.schema.json
+++ b/examples/settings/types/gts.x.core.settings.type.v1~x.platform._.feature_new_dashboard.v1~.schema.json
@@ -30,6 +30,7 @@
   ],
   "x-gts-traits": {
     "scope_class": "cascading",
+    "data_classification": "public",
     "mode": "standard",
     "tenant_visible": true,
     "tenant_overridable": true,

--- a/examples/settings/types/gts.x.core.settings.type.v1~x.platform._.maintenance_mode.v1~.schema.json
+++ b/examples/settings/types/gts.x.core.settings.type.v1~x.platform._.maintenance_mode.v1~.schema.json
@@ -30,6 +30,7 @@
   ],
   "x-gts-traits": {
     "scope_class": "global",
+    "data_classification": "public",
     "mode": "standard",
     "tenant_visible": true,
     "tenant_overridable": false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated settings schemas to represent data classification as metadata associated with each setting type rather than as a shared envelope field.
  - Added supported classification values—`public`, `pii`, and `secret`—with `public` as the default.
  - Marked feature dashboard and maintenance mode settings as publicly classified.
  - Updated example configuration entries to omit the former top-level classification field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->